### PR TITLE
Adds simple social shares

### DIFF
--- a/harp.json
+++ b/harp.json
@@ -31,7 +31,8 @@
       "googleverification": null,
       "facebookid": null,
       "socialimage": "images/social-image.jpg",
-      "appleid": null
+      "appleid": null,
+      "twitter": "thatianrose"
     },
     "thanks": {
       "firstlast": {

--- a/public/_includes/header.ejs
+++ b/public/_includes/header.ejs
@@ -1,5 +1,6 @@
 <header class="site-header">
   <div class="site-logo"><a href="https://github.com/ianrose/storysettings">Storysettings</a></div>
   <div class="site-title"><%- title %></div>
+  <% include /share %>
   <a class="site-top js-top" href="#">Top</a>
 </header>

--- a/public/_includes/share.ejs
+++ b/public/_includes/share.ejs
@@ -1,0 +1,44 @@
+<%function escapeURI(uri) {
+  return encodeURIComponent(uri);
+}%>
+<%function escapeString(string) {
+  return encodeURI(string);
+}%>
+<%var shareURL = escapeURI(url)%>
+<ul class="share">
+  <li>
+    <a href="https://www.facebook.com/sharer/sharer.php?u=<%-shareURL%>&t=<%-escapeString(title)%>" target="_blank" title="Share on Facebook">
+      <svg version="1.1" x="0" y="0" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+        <title>Facebook Logo</title>
+        <desc>Share on Facebook</desc>
+        <path d="M17 1H3C1.9 1 1 1.9 1 3v14c0 1.1 0.9 2 2 2h7v-7H8V9.53h2V7.48c0-2.16 1.21-3.68 3.77-3.68l1.8 0v2.61h-1.2C13.38 6.4 13 7.14 13 7.84v1.69h2.57L15 12h-2v7h4c1.1 0 2-0.9 2-2V3C19 1.9 18.1 1 17 1z"></path>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a href="https://twitter.com/intent/tweet?source=<%-shareURL%>&text=<%-escapeString(title)%>:%20<%-shareURL%>&via=<%-service.twitter%>" target="_blank" title="Tweet">
+      <svg version="1.1" x="0px" y="0px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+        <title>Twitter Logo</title>
+        <desc>Share on Twitter</desc>
+        <path d="M17.316 6.246c0.008 0.2 0 0.3 0 0.488c0 4.99-3.797 10.742-10.74 10.742c-2.133 0-4.116-0.625-5.787-1.697 c0.296 0 0.6 0.1 0.9 0.053c1.77 0 3.397-0.604 4.688-1.615c-1.651-0.031-3.046-1.121-3.526-2.621 c0.23 0 0.5 0.1 0.7 0.066c0.345 0 0.679-0.045 0.995-0.131c-1.727-0.348-3.028-1.873-3.028-3.703c0-0.016 0-0.031 0-0.047 c0.509 0.3 1.1 0.5 1.7 0.473c-1.013-0.678-1.68-1.832-1.68-3.143c0-0.691 0.186-1.34 0.512-1.898 C3.942 5.5 6.7 7 9.9 7.158C9.798 6.9 9.8 6.6 9.8 6.297c0-2.084 1.689-3.773 3.774-3.773 c1.086 0 2.1 0.5 2.8 1.191c0.859-0.17 1.667-0.484 2.397-0.916c-0.282 0.881-0.881 1.621-1.66 2.1 c0.764-0.092 1.49-0.293 2.168-0.594C18.694 5.1 18.1 5.7 17.3 6.246z"></path>
+      </svg>
+    </a></li>
+  <li>
+    <a href="https://plus.google.com/share?url=<%-shareURL%>" target="_blank" title="Share on Google+">
+      <svg version="1.1" x="0" y="0" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+        <title>Google Plus Logo</title>
+        <desc>Share on Google Plus</desc>
+        <path d="M1.99 5.59c0 1.49 0.5 2.57 1.48 3.21 0.81 0.52 1.74 0.6 2.23 0.6 0.12 0 0.21-0.01 0.28-0.01 0 0-0.15 1 0.59 2H6.53c-1.29 0-5.49 0.27-5.49 3.73 0 3.52 3.86 3.7 4.64 3.7 0.06 0 0.1 0 0.1 0 0.01 0 0.06 0 0.16 0 0.5 0 1.78-0.06 2.98-0.64 1.55-0.75 2.33-2.06 2.33-3.88 0-1.76-1.2-2.81-2.07-3.58 -0.53-0.47-0.99-0.87-0.99-1.27 0-0.4 0.34-0.7 0.76-1.08 0.69-0.61 1.34-1.49 1.34-3.15 0-1.46-0.19-2.44-1.35-3.06 0.12-0.06 0.55-0.11 0.76-0.14 0.63-0.09 1.55-0.18 1.55-0.7V1.2H6.64C6.59 1.2 1.99 1.37 1.99 5.59zM9.41 14.6c0.09 1.41-1.11 2.44-2.92 2.57 -1.83 0.14-3.34-0.69-3.43-2.1 -0.04-0.68 0.25-1.34 0.84-1.86 0.59-0.53 1.4-0.86 2.28-0.93 0.1-0.01 0.21-0.01 0.31-0.01C8.18 12.28 9.33 13.28 9.41 14.6zM8.21 4.63c0.45 1.59-0.23 3.25-1.32 3.55C6.77 8.21 6.64 8.23 6.51 8.23c-0.99 0-1.98-1.01-2.35-2.39C3.96 5.06 3.98 4.38 4.21 3.73c0.23-0.64 0.64-1.08 1.16-1.23 0.13-0.04 0.25-0.05 0.39-0.05C6.96 2.45 7.73 2.95 8.21 4.63zM16 8V5h-2v3h-3v2h3v3h2v-3h3V8H16z"></path>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a href="mailto:?subject=<%-escapeString(title)%>%20by%20<%-escapeString(name)%>&body=<%-escapeString(description)%>:%20<%-shareURL%>" target="_blank" title="Email">
+      <svg version="1.1" id="Mail" x="0" y="0" viewBox="0 0 20 20" xml:space="preserve">
+        <title>Email Icon</title>
+        <desc>Email page link</desc>
+        <path d="M1.57 5.29c0.49 0.26 7.25 3.89 7.5 4.03C9.33 9.45 9.65 9.51 9.98 9.51c0.33 0 0.65-0.06 0.91-0.2s7.01-3.77 7.5-4.03C18.88 5.02 19.34 4 18.44 4H1.52C0.62 4 1.09 5.02 1.57 5.29zM18.61 7.49c-0.56 0.29-7.39 3.85-7.73 4.03s-0.58 0.2-0.91 0.2 -0.57-0.02-0.91-0.2S1.94 7.78 1.39 7.49C1 7.28 1 7.52 1 7.71S1 15 1 15c0 0.42 0.57 1 1 1h16c0.43 0 1-0.58 1-1 0 0 0-7.11 0-7.29S19 7.29 18.61 7.49z"></path>
+      </svg>
+    </a>
+  </li>
+</ul>

--- a/public/styles/components/_share.scss
+++ b/public/styles/components/_share.scss
@@ -1,0 +1,16 @@
+.share {
+  float: left;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.share li {
+  display: inline-block;
+}
+
+.share svg {
+  fill: #000;
+  height: 18px;
+  width: 18px;
+}

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -21,6 +21,7 @@
 @import "components/footnotes";
 @import "components/media";
 @import "components/pullquote";
+@import "components/share";
 @import "components/sidebar";
 @import "components/site-header";
 @import "components/site-logo";


### PR DESCRIPTION
Adds facebook, twitter, google plus, and email share in the header.

During the process came up with this handy helper that uses Harp's `current.path` https://gist.github.com/ianrose/39b1863f474ba2a27694 However at this point keeping it at one page for now so holding off on using.